### PR TITLE
Adding Feff input generator from general structure files

### DIFF
--- a/larch/wxlib/__init__.py
+++ b/larch/wxlib/__init__.py
@@ -76,7 +76,7 @@ if HAS_WXPYTHON:
 
     from .feff_browser import FeffResultsFrame, FeffResultsPanel
     from .cif_browser import CIFFrame
-    from .structure_browser import Structure2FeffFrame
+    from .structure2feff_browser import Structure2FeffFrame
 
     _larch_builtins = {'_sys.wx': dict(gcd=gcd,
                                        databrowser=databrowser,

--- a/larch/wxlib/__init__.py
+++ b/larch/wxlib/__init__.py
@@ -76,6 +76,7 @@ if HAS_WXPYTHON:
 
     from .feff_browser import FeffResultsFrame, FeffResultsPanel
     from .cif_browser import CIFFrame
+    from .structure_browser import Structure2FeffFrame
 
     _larch_builtins = {'_sys.wx': dict(gcd=gcd,
                                        databrowser=databrowser,

--- a/larch/wxlib/structure_browser.py
+++ b/larch/wxlib/structure_browser.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python
+"""
+Read Structure input file, Make Feff input file, and run Feff
+"""
+
+import os
+import sys
+import time
+import copy
+from threading import Thread
+import numpy as np
+np.seterr(all='ignore')
+
+from functools import partial
+import wx
+import wx.lib.scrolledpanel as scrolled
+import wx.lib.agw.flatnotebook as fnb
+from wx.adv import AboutBox, AboutDialogInfo
+from matplotlib.ticker import FuncFormatter
+
+from wxmplot import PlotPanel
+from xraydb.chemparser import chemparse
+from xraydb import atomic_number
+
+import larch
+from larch import Group
+from larch.xafs import feff8l, feff6l
+from larch.xrd.cif2feff import cif_sites
+from larch.utils import read_textfile
+from larch.utils.paths import unixpath
+from larch.utils.strutils import fix_filename, unique_name, strict_ascii
+from larch.site_config import user_larchdir
+
+from larch.wxlib import (LarchFrame, FloatSpin, EditableListBox,
+                         FloatCtrl, SetTip, get_icon, SimpleText, pack,
+                         Button, Popup, HLine, FileSave, FileOpen, Choice,
+                         Check, MenuItem, CEN, LEFT, FRAMESTYLE,
+                         Font, FONTSIZE, flatnotebook, LarchUpdaterDialog,
+                         PeriodicTablePanel, FeffResultsPanel, LarchWxApp,
+                         ExceptionPopup, set_color)
+
+
+from larch.xrd import CifStructure, get_amscifdb, find_cifs, get_cif, parse_cif_file
+
+LEFT = wx.ALIGN_LEFT
+CEN |=  wx.ALL
+FNB_STYLE = fnb.FNB_NO_X_BUTTON|fnb.FNB_SMART_TABS
+FNB_STYLE |= fnb.FNB_NO_NAV_BUTTONS|fnb.FNB_NODRAG
+
+MAINSIZE = (850, 750)
+
+class Structure2FeffFrame(wx.Frame):
+    _about = """Larch structure browser for generating and running Feff.
+    
+    Ryuichi Shimogawa <ryuichi.shimogawa@stonybrook.edu>
+    """
+    def __init__(self, parent=None, _larch=None, filename=None, **kws):
+        wx.Frame.__init__(self, parent, -1, size=MAINSIZE, style=FRAMESTYLE)
+
+        title = "Larch FEFF Input Generator and FEFF Runner"
+
+        self.larch = _larch
+        if _larch is None:
+            self.larch = larch.Interpreter()
+        self.larch.eval("# started Structure browser\n")
+        self.larch.eval("if not hasattr('_sys', '_feffruns'): _sys._feffruns = {}")
+
+        # self.cifdb = get_amscifdb()
+        # self.all_minerals = self.cifdb.all_minerals()
+        self.subframes = {}
+        # self.has_xrd1d = False
+        # self.xrd1d_thread = None
+        self.current_cif = None
+        self.SetTitle(title)
+        self.SetSize(MAINSIZE)
+        self.SetFont(Font(FONTSIZE))
+        self.createMainPanel()
+        self.createMenus()
+
+        path = unixpath(os.path.join(user_larchdir, 'feff'))
+        if not os.path.exists(path):
+            os.makedirs(path, mode=493)
+        self.feff_folder = path
+        self.runs_list = []
+        for fname in os.listdir(self.feff_folder):
+            full = os.path.join(self.feff_folder, fname)
+            if os.path.isdir(full):
+                self.runs_list.append(fname)
+
+        self.statusbar = self.CreateStatusBar(2, style=wx.STB_DEFAULT_STYLE)
+        self.statusbar.SetStatusWidths([-3, -1])
+        statusbar_fields = [" ", ""]
+        for i in range(len(statusbar_fields)):
+            self.statusbar.SetStatusText(statusbar_fields[i], i)
+        self.Show()
+
+    def createMainPanel(self):
+        display0 = wx.Display(0)
+        client_area = display0.ClientArea
+        xmin, ymin, xmax, ymax = client_area
+        xpos = int((xmax-xmin)*0.07) + xmin
+        ypos = int((ymax-ymin)*0.09) + ymin
+        self.SetPosition((xpos, ypos))
+
+        # splitter  = wx.SplitterWindow(self, style=wx.SP_LIVE_UPDATE)
+        # splitter.SetMinimumPaneSize(250)
+
+        # leftpanel = wx.Panel(splitter)
+        # self.ciflist = EditableListBox(leftpanel,
+        #                                self.onShowCIF, size=(300,-1))
+        # set_color(self.ciflist, 'list_fg', bg='list_bg')
+        # self.cif_selections = {}
+
+        # sizer = wx.BoxSizer(wx.VERTICAL)
+        # sizer.Add(self.ciflist, 1, LEFT|wx.GROW|wx.ALL, 1)
+        # pack(leftpanel, sizer)
+
+        # right hand side
+        scrolledpanel = scrolled.ScrolledPanel(self)
+        panel = wx.Panel(scrolledpanel)
+        sizer = wx.GridBagSizer(2,2)
+
+        # self.title = SimpleText(panel, 'Search American Mineralogical CIF Database:',
+        #                         size=(500, -1), style=LEFT)
+        # self.title.SetFont(Font(FONTSIZE+2))
+        wids = self.wids = {}
+
+
+        # minlab = SimpleText(panel, ' Mineral Name: ')
+        # minhint= SimpleText(panel, ' example: hem* ')
+        # wids['mineral'] = wx.TextCtrl(panel, value='',   size=(250, -1),
+        #                               style=wx.TE_PROCESS_ENTER)
+        # wids['mineral'].Bind(wx.EVT_TEXT_ENTER, self.onSearch)
+
+        # authlab = SimpleText(panel, ' Author Name: ')
+        # wids['author'] = wx.TextCtrl(panel, value='',   size=(250, -1))
+
+        # journlab = SimpleText(panel, ' Journal Name: ')
+        # wids['journal'] = wx.TextCtrl(panel, value='',   size=(250, -1))
+
+        # elemlab = SimpleText(panel, ' Include Elements: ')
+        # elemhint= SimpleText(panel, ' example: O, Fe, Si ')
+
+        # wids['contains_elements'] = wx.TextCtrl(panel, value='', size=(250, -1))
+        # exelemlab = SimpleText(panel, ' Exclude Elements: ')
+        # wids['excludes_elements'] = wx.TextCtrl(panel, value='', size=(250, -1))
+        # wids['excludes_elements'].Enable()
+        # wids['strict_contains'] = Check(panel, default=False,
+        #                                label='Include only the elements listed',
+        #                                action=self.onStrict)
+
+        # wids['full_occupancy'] = Check(panel, default=False,
+        #                                label='Only Structures with Full Occupancy')
+
+        # wids['search']   = Button(panel, 'Search for CIFs',  action=self.onSearch)
+        # wids['get_feff'] = Button(panel, 'Get Feff Input', action=self.onGetFeff)
+        # wids['get_feff'].Disable()
+
+        folderlab = SimpleText(panel, ' Feff Folder: ')
+        wids['run_folder'] = wx.TextCtrl(panel, value='calc1', size=(250, -1))
+
+        wids['run_feff'] = Button(panel, ' Run Feff ',
+                                  action=self.onRunFeff)
+        wids['run_feff'].Disable()
+        wids['without_h'] = Check(panel, default=True, label='Remove H atoms',
+                                  action=self.onGetFeff)
+
+
+        wids['central_atom'] = Choice(panel, choices=['<empty>'], size=(80, -1),
+                                      action=self.onCentralAtom)
+        wids['edge']         = Choice(panel, choices=['K', 'L3', 'L2', 'L1',
+                                                      'M5', 'M4'],
+                                      size=(80, -1),
+                                      action=self.onGetFeff)
+
+        wids['feffvers']      = Choice(panel, choices=['6', '8'], default=1,
+                                       size=(80, -1),
+                                      action=self.onGetFeff)
+        wids['site']         = Choice(panel, choices=['1', '2', '3', '4'],
+                                      size=(80, -1),
+                                      action=self.onGetFeff)
+        wids['cluster_size'] = FloatSpin(panel, value=7.0, digits=2,
+                                         increment=0.1, max_val=10,
+                                         action=self.onGetFeff)
+        wids['central_atom'].Disable()
+        wids['edge'].Disable()
+        wids['cluster_size'].Disable()
+        catomlab = SimpleText(panel, ' Absorbing Atom: ')
+        sitelab  = SimpleText(panel, ' Crystal Site: ')
+        edgelab  = SimpleText(panel, ' Edge: ')
+        csizelab = SimpleText(panel, ' Cluster Size (\u212B): ')
+        fverslab = SimpleText(panel, ' Feff Version:')
+
+        ir = 0
+        # sizer.Add(self.title,     (0, 0), (1, 6), LEFT, 2)
+
+        # ir += 1
+        # sizer.Add(HLine(panel, size=(550, 2)), (ir, 0), (1, 6), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(minlab,          (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['mineral'], (ir, 1), (1, 3), LEFT, 3)
+        # sizer.Add(minhint,         (ir, 4), (1, 2), LEFT, 3)
+        # ir += 1
+        # sizer.Add(authlab,        (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['author'], (ir, 1), (1, 3), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(journlab,        (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['journal'], (ir, 1), (1, 3), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(elemlab,        (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['contains_elements'], (ir, 1), (1, 3), LEFT, 3)
+        # sizer.Add(elemhint,         (ir, 4), (1, 3), LEFT, 2)
+
+        # ir += 1
+        # sizer.Add(exelemlab,        (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['excludes_elements'], (ir, 1), (1, 3), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(wids['search'],          (ir, 0), (1, 1), LEFT, 3)
+        # sizer.Add(wids['strict_contains'], (ir, 1), (1, 4), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(wids['full_occupancy'], (ir, 1), (1, 4), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(HLine(panel, size=(550, 2)), (ir, 0), (1, 6), LEFT, 3)
+
+        # ir += 1
+
+        sizer.Add(catomlab,             (ir, 0), (1, 1), LEFT, 3)
+        sizer.Add(wids['central_atom'], (ir, 1), (1, 1), LEFT, 3)
+        sizer.Add(sitelab,              (ir, 2), (1, 1), LEFT, 3)
+        sizer.Add(wids['site'],         (ir, 3), (1, 1), LEFT, 3)
+        sizer.Add(edgelab,              (ir, 4), (1, 1), LEFT, 3)
+        sizer.Add(wids['edge'],         (ir, 5), (1, 1), LEFT, 3)
+
+        ir += 1
+        sizer.Add(csizelab,             (ir, 0), (1, 1), LEFT, 3)
+        sizer.Add(wids['cluster_size'], (ir, 1), (1, 1), LEFT, 3)
+        sizer.Add(fverslab,             (ir, 2), (1, 1), LEFT, 3)
+        sizer.Add(wids['feffvers'],     (ir, 3), (1, 1), LEFT, 3)
+        sizer.Add(wids['without_h'],    (ir, 4), (1, 2), LEFT, 3)
+
+        ir += 1
+        sizer.Add(folderlab,             (ir, 0), (1, 1), LEFT, 3)
+        sizer.Add(wids['run_folder'],    (ir, 1), (1, 4), LEFT, 3)
+        sizer.Add(wids['run_feff'],      (ir, 5), (1, 1), LEFT, 3)
+
+        # ir += 1
+        # sizer.Add(HLine(panel, size=(550, 2)), (ir, 0), (1, 6), LEFT, 3)
+
+        pack(panel, sizer)
+
+        self.nb = flatnotebook(scrolledpanel, {}, on_change=self.onNBChanged)
+
+        self.feffresults = FeffResultsPanel(scrolledpanel, _larch=self.larch)
+
+        # def _swallow_plot_messages(s, panel=0):
+        #     pass
+
+        # self.plotpanel = PlotPanel(rightpanel, messenger=_swallow_plot_messages)
+        # try:
+        #     plotopts = self.larch.symtable._sys.wx.plotopts
+        #     self.plotpanel.conf.set_theme(plotopts['theme'])
+        #     self.plotpanel.conf.enable_grid(plotopts['show_grid'])
+        # except:
+        #     pass
+
+        # self.plotpanel.SetMinSize((250, 250))
+        # self.plotpanel.SetMaxSize((600, 450))
+        # self.plotpanel.onPanelExposed = self.showXRD1D
+
+        structure_panel = wx.Panel(scrolledpanel)
+        wids['structure_text'] = wx.TextCtrl(structure_panel, value='<STRUCTURE TEXT>',
+                                       style=wx.TE_MULTILINE|wx.TE_READONLY,
+                                       size=(300, 350))
+        wids['structure_text'].SetFont(Font(FONTSIZE+1))
+        structure_sizer = wx.BoxSizer(wx.VERTICAL)
+        structure_sizer.Add(wids['structure_text'], 1, LEFT|wx.GROW, 1)
+        pack(structure_panel, structure_sizer)
+
+        feff_panel = wx.Panel(scrolledpanel)
+        wids['feff_text'] = wx.TextCtrl(feff_panel,
+                                       value='<Feff Input Text>',
+                                       style=wx.TE_MULTILINE,
+                                       size=(300, 350))
+        wids['feff_text'].CanCopy()
+
+        feff_panel.onPanelExposed = self.onGetFeff
+        wids['feff_text'].SetFont(Font(FONTSIZE+1))
+        feff_sizer = wx.BoxSizer(wx.VERTICAL)
+        feff_sizer.Add(wids['feff_text'], 1, LEFT|wx.GROW, 1)
+        pack(feff_panel, feff_sizer)
+
+        feffout_panel = wx.Panel(scrolledpanel)
+        wids['feffout_text'] = wx.TextCtrl(feffout_panel,
+                                           value='<Feff Output>',
+                                           style=wx.TE_MULTILINE,
+                                           size=(300, 350))
+        wids['feffout_text'].CanCopy()
+        wids['feffout_text'].SetFont(Font(FONTSIZE+1))
+        feffout_sizer = wx.BoxSizer(wx.VERTICAL)
+        feffout_sizer.Add(wids['feffout_text'], 1, LEFT|wx.GROW, 1)
+        pack(feffout_panel, feffout_sizer)
+
+        self.nbpages = []
+        for label, page in (('Structure Text',  structure_panel),
+                            ('Feff Input Text', feff_panel),
+                            ('Feff Output Text', feffout_panel),
+                            ('Feff Results',    self.feffresults),
+                            ):
+            self.nb.AddPage(page, label, True)
+            self.nbpages.append((label, page))
+        self.nb.SetSelection(0)
+
+        r_sizer = wx.BoxSizer(wx.VERTICAL)
+        r_sizer.Add(panel, 0, LEFT|wx.GROW|wx.ALL)
+        r_sizer.Add(self.nb, 1, LEFT|wx.GROW, 2)
+        pack(scrolledpanel, r_sizer)
+        scrolledpanel.SetupScrolling()
+        # splitter.SplitVertically(leftpanel, rightpanel, 1)
+
+    def get_nbpage(self, name):
+        "get nb page by name"
+        name = name.lower()
+        for i, dat in enumerate(self.nbpages):
+            label, page = dat
+            if name in label.lower():
+                return i, page
+        return (0, self.npbages[0][1])
+
+
+    def onShowCIF(self, event=None, cif_id=None):
+        if cif_id is not None:
+            cif = get_cif(cif_id)
+            self.cif_label = '%d' % cif_id
+        elif event is not None:
+            self.cif_label = event.GetString()
+            cif = get_cif(self.cif_selections[self.cif_label])
+        self.current_cif = cif
+        self.has_xrd1d = False
+        self.wids['structure_text'].SetValue(cif.ciftext)
+        elems =  chemparse(cif.formula.replace(' ', ''))
+
+        self.wids['central_atom'].Enable()
+        self.wids['edge'].Enable()
+        self.wids['cluster_size'].Enable()
+        # self.wids['get_feff'].Enable()
+
+        self.wids['central_atom'].Clear()
+        self.wids['central_atom'].AppendItems(list(elems.keys()))
+        self.wids['central_atom'].Select(0)
+
+        el0 = list(elems.keys())[0]
+        edge_val = 'K' if atomic_number(el0) < 60 else 'L3'
+        self.wids['edge'].SetStringSelection(edge_val)
+
+        sites = cif_sites(cif.ciftext, absorber=el0)
+        try:
+            sites = ['%d' % (i+1) for i in range(len(sites))]
+        except:
+            title = "Could not make sense of atomic sites"
+            message = [f"Elements: {list(elems.keys())}",
+                       f"Sites: {sites}"]
+            ExceptionPopup(self, title, message)
+
+        self.wids['site'].Clear()
+        self.wids['site'].AppendItems(sites)
+        self.wids['site'].Select(0)
+        i, p = self.get_nbpage('Structure Text')
+        self.nb.SetSelection(i)
+
+    def onCentralAtom(self, event=None):
+        cif  = self.current_cif
+        if cif is None:
+            return
+        catom = event.GetString()
+        try:
+            sites = cif_sites(cif.ciftext, absorber=catom)
+            sites = ['%d' % (i+1) for i in range(len(sites))]
+            self.wids['site'].Clear()
+            self.wids['site'].AppendItems(sites)
+            self.wids['site'].Select(0)
+        except:
+            self.write_message(f"could not get sites for central atom '{catom}'")
+            title = f"Could not get sites for central atom '{catom}'"
+            message = []
+            ExceptionPopup(self, title, message)
+
+        edge_val = 'K' if atomic_number(catom) < 60 else 'L3'
+        self.wids['edge'].SetStringSelection(edge_val)
+        self.onGetFeff()
+
+    def onGetFeff(self, event=None):
+        cif  = self.current_cif
+        if cif is None:
+            return
+        edge  = self.wids['edge'].GetStringSelection()
+        version8 = '8' == self.wids['feffvers'].GetStringSelection()
+        catom = self.wids['central_atom'].GetStringSelection()
+        asite = int(self.wids['site'].GetStringSelection())
+        csize = self.wids['cluster_size'].GetValue()
+        with_h = not self.wids['without_h'].IsChecked()
+        mineral = cif.get_mineralname()
+        folder = f'{catom:s}{asite:d}_{edge:s}_{mineral}_cif{cif.ams_id:d}'
+        folder = unique_name(fix_filename(folder), self.runs_list)
+
+        fefftext = cif.get_feffinp(catom, edge=edge, cluster_size=csize,
+                                   absorber_site=asite, version8=version8,
+                                   with_h=with_h)
+
+        self.wids['run_folder'].SetValue(folder)
+        self.wids['feff_text'].SetValue(fefftext)
+        self.wids['run_feff'].Enable()
+        i, p = self.get_nbpage('Feff Input')
+        self.nb.SetSelection(i)
+
+    def onRunFeff(self, event=None):
+        fefftext = self.wids['feff_text'].GetValue()
+        if len(fefftext) < 100 or 'ATOMS' not in fefftext:
+            return
+
+        ciftext = self.wids['structure_text'].GetValue()
+        cif  = self.current_cif
+        cif_fname = None
+        if cif is not None and len(ciftext) > 100:
+            mineral = cif.get_mineralname()
+            cif_fname = f'{mineral}_cif{cif.ams_id:d}.cif'
+
+        # cc = self.current_cif
+        # edge  = self.wids['edge'].GetStringSelection()
+        # catom = self.wids['central_atom'].GetStringSelection()
+        # asite = int(self.wids['site'].GetStringSelection())
+        # mineral = cc.get_mineralname()
+        # folder = f'{catom:s}{asite:d}_{edge:s}_{mineral}_cif{cc.ams_id:d}'
+        # folder = unixpath(os.path.join(self.feff_folder, folder))
+        version8 = '8' == self.wids['feffvers'].GetStringSelection()
+
+        fname = self.wids['run_folder'].GetValue()
+        fname = unique_name(fix_filename(fname), self.runs_list)
+        self.runs_list.append(fname)
+        folder = unixpath(os.path.join(self.feff_folder, fname))
+
+        if not os.path.exists(folder):
+            os.makedirs(folder, mode=493)
+        ix, p = self.get_nbpage('Feff Output')
+        self.nb.SetSelection(ix)
+
+        self.folder = folder
+        out = self.wids['feffout_text']
+        out.Clear()
+        out.SetInsertionPoint(0)
+        out.WriteText(f'########\n###\n# Run Feff in folder: {folder:s}\n')
+        out.SetInsertionPoint(out.GetLastPosition())
+        out.WriteText('###\n########\n')
+        out.SetInsertionPoint(out.GetLastPosition())
+
+        fname = unixpath(os.path.join(folder, 'feff.inp'))
+        with open(fname, 'w', encoding=sys.getdefaultencoding()) as fh:
+            fh.write(strict_ascii(fefftext))
+
+        if cif_fname is not None:
+            cname = unixpath(os.path.join(folder, cif_fname))
+            with open(cname, 'w', encoding=sys.getdefaultencoding()) as fh:
+                fh.write(strict_ascii(ciftext))
+
+        wx.CallAfter(self.run_feff, folder, version8=version8)
+        # feffexe, folder=dirname, message_writer=self.feff_output)
+
+    def run_feff(self, folder=None, version8=True):
+        _, dname = os.path.split(folder)
+        prog, cmd = feff8l, 'feff8l'
+        if not version8:
+            prog, cmd = feff6l, 'feff6l'
+        command = f"{cmd:s}(folder='{folder:s}')"
+        self.larch.eval(f"## running Feff as:\n#  {command:s}\n##\n")
+
+        prog(folder=folder, message_writer=self.feff_output)
+        self.larch.eval("## gathering results:\n")
+        self.larch.eval(f"_sys._feffruns['{dname:s}'] = get_feff_pathinfo('{folder:s}')")
+        this_feffrun = self.larch.symtable._sys._feffruns[f'{dname:s}']
+        self.feffresults.set_feffresult(this_feffrun)
+        ix, p = self.get_nbpage('Feff Results')
+        self.nb.SetSelection(ix)
+
+        # clean up unused, intermediate Feff files
+        for fname in os.listdir(folder):
+            if (fname.endswith('.json') or fname.endswith('.pad') or
+                fname.endswith('.bin') or fname.startswith('log') or
+                fname in ('chi.dat', 'xmu.dat', 'misc.dat')):
+                os.unlink(unixpath(os.path.join(folder, fname)))
+
+    def feff_output(self, text):
+        out = self.wids['feffout_text']
+        ix, p = self.get_nbpage('Feff Output')
+        self.nb.SetSelection(ix)
+        pos0 = out.GetLastPosition()
+        if not text.endswith('\n'):
+            text = '%s\n' % text
+        out.WriteText(text)
+        out.SetInsertionPoint(out.GetLastPosition())
+        out.Update()
+        out.Refresh()
+
+    def onExportFeff(self, event=None):
+        if self.current_cif is None:
+            return
+        fefftext = self.wids['feff_text'].GetValue()
+        if len(fefftext) < 20:
+            return
+        cc = self.current_cif
+        minname = cc.get_mineralname()
+        fname = f'{minname}_cif{cc.ams_id:d}_feff.inp'
+        wildcard = 'Feff Inut files (*.inp)|*.inp|All files (*.*)|*.*'
+        path = FileSave(self, message='Save Feff File',
+                        wildcard=wildcard,
+                        default_file=fname)
+        if path is not None:
+            with open(path, 'w', encoding=sys.getdefaultencoding()) as fh:
+                fh.write(fefftext)
+            self.write_message("Wrote Feff file %s" % path, 0)
+
+
+    def onExportCIF(self, event=None):
+        if self.current_cif is None:
+            return
+        cc = self.current_cif
+        minname = cc.get_mineralname()
+        fname = f'{minname}_cif{cc.ams_id:d}.cif'
+        wildcard = 'CIF files (*.cif)|*.cif|All files (*.*)|*.*'
+        path = FileSave(self, message='Save CIF File',
+                        wildcard=wildcard,
+                        default_file=fname)
+        if path is not None:
+            with open(path, 'w', encoding=sys.getdefaultencoding()) as fh:
+                fh.write(cc.ciftext)
+            self.write_message("Wrote CIF file %s" % path, 0)
+
+    def onImportCIF(self, event=None):
+        wildcard = 'CIF files (*.cif)|*.cif|All files (*.*)|*.*'
+        path = FileOpen(self, message='Open CIF File',
+                        wildcard=wildcard, default_file='My.cif')
+
+        if path is not None:
+            try:
+                cif_data = parse_cif_file(path)
+            except:
+                title = f"Cannot parse CIF file '{path}'"
+                message = [f"Error reading CIF File: {path}"]
+                ExceptionPopup(self, title, message)
+                return
+
+            try:
+                cif_id = self.cifdb.add_ciffile(path)
+            except:
+                title = f"Cannot add CIF from '{path}' to CIF database"
+                message = [f"Error adding CIF File to database: {path}"]
+                ExceptionPopup(self, title, message)
+                return
+
+            try:
+                self.onShowCIF(cif_id=cif_id)
+            except:
+                title = f"Cannot show CIF from '{path}'"
+                message = [f"Error displaying CIF File: {path}"]
+                ExceptionPopup(self, title, message)
+
+    def onImportStructure(self, event=None):
+        wildcard = 'Strucuture files (*.cif)|*.cif|All files (*.*)|*.*'
+        path = FileOpen(self, message='Open CIF File',
+                        wildcard=wildcard, default_file='My.cif')
+
+        if path is not None:
+            try:
+                cif_data = parse_cif_file(path)
+            except:
+                title = f"Cannot parse CIF file '{path}'"
+                message = [f"Error reading CIF File: {path}"]
+                ExceptionPopup(self, title, message)
+                return
+
+            try:
+                cif_id = self.cifdb.add_ciffile(path)
+            except:
+                title = f"Cannot add CIF from '{path}' to CIF database"
+                message = [f"Error adding CIF File to database: {path}"]
+                ExceptionPopup(self, title, message)
+                return
+
+            try:
+                self.onShowCIF(cif_id=cif_id)
+            except:
+                title = f"Cannot show CIF from '{path}'"
+                message = [f"Error displaying CIF File: {path}"]
+                ExceptionPopup(self, title, message)
+
+    def onImportFeff(self, event=None):
+        wildcard = 'Feff input files (*.inp)|*.inp|All files (*.*)|*.*'
+        path = FileOpen(self, message='Open Feff Input File',
+                        wildcard=wildcard, default_file='feff.inp')
+        if path is not None:
+            fefftext = None
+            _, fname = os.path.split(path)
+            fname = fname.replace('.inp', '_run')
+            fname = unique_name(fix_filename(fname), self.runs_list)
+            fefftext = read_textfile(path)
+            if fefftext is not None:
+                self.wids['feff_text'].SetValue(fefftext)
+                self.wids['run_folder'].SetValue(fname)
+                self.wids['run_feff'].Enable()
+                i, p = self.get_nbpage('Feff Input')
+                self.nb.SetSelection(i)
+
+    def onFeffFolder(self, eventa=None):
+        "prompt for Feff Folder"
+        dlg = wx.DirDialog(self, 'Select Main Folder for Feff Calculations',
+                           style=wx.DD_DEFAULT_STYLE|wx.DD_CHANGE_DIR)
+
+        dlg.SetPath(self.feff_folder)
+        if  dlg.ShowModal() == wx.ID_CANCEL:
+            return None
+        path = os.path.abspath(dlg.GetPath())
+        if not os.path.exists(path):
+            os.makedirs(path, mode=493)
+        self.feff_folder = path
+
+
+    def onNBChanged(self, event=None):
+        callback = getattr(self.nb.GetCurrentPage(), 'onPanelExposed', None)
+        if callable(callback):
+            callback()
+
+    def onSelAll(self, event=None):
+        self.controller.filelist.select_all()
+
+    def onSelNone(self, event=None):
+        self.controller.filelist.select_none()
+
+    def write_message(self, msg, panel=0):
+        """write a message to the Status Bar"""
+        self.statusbar.SetStatusText(msg, panel)
+
+    def createMenus(self):
+        # ppnl = self.plotpanel
+        self.menubar = wx.MenuBar()
+        fmenu = wx.Menu()
+        group_menu = wx.Menu()
+        data_menu = wx.Menu()
+        ppeak_menu = wx.Menu()
+        m = {}
+
+        MenuItem(self, fmenu, "&Open CIF File\tCtrl+O",
+                 "Open Structure File",  self.onImportCIF)
+
+        # MenuItem(self, fmenu, "&Save CIF File\tCtrl+S",
+                #  "Save CIF File",  self.onExportCIF)
+
+        MenuItem(self, fmenu, "Open Feff Input File",
+                 "Open Feff input File",  self.onImportFeff)
+
+        MenuItem(self, fmenu, "Save &Feff Inp File\tCtrl+F",
+                 "Save Feff6 File",  self.onExportFeff)
+
+        fmenu.AppendSeparator()
+        MenuItem(self, fmenu, "Select Main Feff Folder",
+                 "Select Main Folder for running Feff",
+                 self.onFeffFolder)
+        fmenu.AppendSeparator()
+        MenuItem(self, fmenu, "Quit",  "Exit", self.onClose)
+
+        self.menubar.Append(fmenu, "&File")
+
+        self.SetMenuBar(self.menubar)
+        self.Bind(wx.EVT_CLOSE,  self.onClose)
+
+    def onClose(self, event=None):
+        self.Destroy()
+
+
+class Structure2FeffViewer(LarchWxApp):
+    def __init__(self, filename=None, version_info=None,  **kws):
+        self.filename = filename
+        LarchWxApp.__init__(self, version_info=version_info, **kws)
+
+    def createApp(self):
+        frame = Structure2FeffFrame(filename=self.filename,
+                         version_info=self.version_info)
+        self.SetTopWindow(frame)
+        return True
+
+def structure_viewer(**kws):
+    Structure2FeffViewer(**kws)
+
+if __name__ == '__main__':
+    Structure2FeffViewer().MainLoop()

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -39,7 +39,7 @@ from larch.wxlib import (LarchFrame, ColumnDataFileFrame, AthenaImporter,
                          Choice, Check, MenuItem, HyperText, set_color, COLORS,
                          CEN, LEFT, FRAMESTYLE, Font, FONTSIZE,
                          flatnotebook, LarchUpdaterDialog, GridPanel,
-                         CIFFrame, FeffResultsFrame, LarchWxApp, OkCancel,
+                         CIFFrame, Structure2FeffFrame, FeffResultsFrame, LarchWxApp, OkCancel,
                          ExceptionPopup, set_color)
 
 
@@ -605,6 +605,8 @@ class XASFrame(wx.Frame):
 
         MenuItem(self, feff_menu, "Browse CIF Structures, Run Feff",
                  "Browse CIF Structure, run Feff", self.onCIFBrowse)
+        MenuItem(self, feff_menu, "Browse Structures, Run Feff",
+                 "Browse Structure, run Feff", self.onStructureBrowse)
         MenuItem(self, feff_menu, "Browse Feff Calculations",
                  "Browse Feff Calculations, Get Feff Paths", self.onFeffBrowse)
 
@@ -1131,6 +1133,9 @@ before clearing"""
 
     def onCIFBrowse(self, event=None):
         self.show_subframe('cif_feff', CIFFrame, _larch=self.larch)
+
+    def onStructureBrowse(self, event=None):
+        self.show_subframe('structure_feff', Structure2FeffFrame, _larch=self.larch)
 
     def onFeffBrowse(self, event=None):
         path_importer = self.get_nbpage('feffit')[1].add_path

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -605,8 +605,8 @@ class XASFrame(wx.Frame):
 
         MenuItem(self, feff_menu, "Browse CIF Structures, Run Feff",
                  "Browse CIF Structure, run Feff", self.onCIFBrowse)
-        MenuItem(self, feff_menu, "Browse Structures, Run Feff",
-                 "Browse Structure, run Feff", self.onStructureBrowse)
+        MenuItem(self, feff_menu, "Generate Feff input from general structures, Run Feff",
+                 "Generate Feff input from general structures, run Feff", self.onStructureBrowse)
         MenuItem(self, feff_menu, "Browse Feff Calculations",
                  "Browse Feff Calculations, Get Feff Paths", self.onFeffBrowse)
 

--- a/larch/xrd/structure2feff.py
+++ b/larch/xrd/structure2feff.py
@@ -1,0 +1,314 @@
+import os
+import random
+
+HAS_PYMATGEN = False
+try:
+    from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+    from pymatgen.core import Molecule, IMolecule, IStructure
+    HAS_PYMATGEN = True
+except:
+    HAS_PYMATGEN = False
+
+from xraydb import atomic_symbol, atomic_number, xray_edge
+from larch.utils.strutils import fix_varname, strict_ascii
+
+
+def get_atom_map(structure):
+    """generalization of pymatgen atom map
+    Returns:
+        dict of ipots
+    """
+    unique_pot_atoms = []
+    all_sites  = []
+    for site in structure:
+        for elem in site.species.elements:
+            if elem.symbol not in unique_pot_atoms:
+                unique_pot_atoms.append(elem.symbol)
+
+    atom_map = {}
+    for i, atom in enumerate(unique_pot_atoms):
+        atom_map[atom] = i + 1
+    return atom_map
+
+
+def read_structure(structure_text, fmt="cif"):
+    """read structure from text
+
+    Arguments
+    ---------
+      structure_text (string):  text of structure file
+      fmt (string):             format of structure file (cif, poscar, etc)
+
+    Returns
+    -------
+      pymatgen Structure object or Molecule object
+    """
+    if not HAS_PYMATGEN:
+        raise ImportError('pymatgen required')
+    try:
+        if fmt.lower() in ('cif', 'poscar', 'contcar', 'chgcar', 'locpot', 'cssr', 'vasprun.xml'):
+            struct = IStructure.from_str(structure_text, fmt, merge_tol=5.e-4)
+        else:
+            struct = IMolecule.from_str(structure_text, fmt)
+        parse_ok = True
+        file_found = True
+        
+    except:
+        parse_ok = False
+        file_found = False
+        if os.path.exists(structure_text):
+            file_found = True
+            fmt = os.path.splitext(structure_text)[-1].lower()
+            try:
+                if fmt.lower() in ('cif', 'poscar', 'contcar', 'chgcar', 'locpot', 'cssr', 'vasprun.xml'):
+                    struct = IStructure.from_file(structure_text, merge_tol=5.e-4)
+                else:
+                    struct = IMolecule.from_file(structure_text)
+                parse_ok = True
+            except:
+                parse_ok = False
+
+    if not parse_ok:
+        if not file_found:
+            raise FileNotFoundError(f'file {structure_text:s} not found')
+        else:
+            raise ValueError('invalid text of structure file')
+    return struct
+
+def structure_sites(structure_text, absorber=None, fmt='cif'):
+    "return list of sites for the structure"
+    struct = read_structure(structure_text, fmt=fmt)
+    out = struct.sites
+    if absorber is not None:
+        abname = absorber.lower()
+        out = []
+        for site in struct.sites:
+            species = site.species_string.lower()
+            if ',' in species and ':' in species: # multi-occupancy site
+                for siteocc in species.split(','):
+                    sname, occ = siteocc.split(':')
+                    if sname.strip() == abname:
+                        out.append(site)
+            elif species == abname:
+                out.append(site)
+        if len(out) == 0:
+            out = struct.sites[0]
+    return out
+
+def parse_structure(structure_text, fmt='cif', fname="default.filename"):
+    try:
+        struct = read_structure(structure_text, fmt=fmt)
+    except ValueError:
+        return '# could not read structure file'
+    
+    return {'formula': struct.composition.reduced_formula, 'sites': struct.sites, 'structure_text': structure_text, 'fmt': fmt, 'fname': fname}
+    
+
+def structure2feffinp(structure_text, absorber, edge=None, cluster_size=8.0, absorber_site=1,
+                      site_index=None, extra_titles=None, with_h=False, version8=True, fmt='cif'):
+    """convert structure text to Feff8 or Feff6l input file
+
+    Arguments
+    ---------
+      structure_text (string):  text of CIF file or name of the CIF file.
+      absorber (string or int): atomic symbol or atomic number of absorbing element
+                                (see Note 1)
+      edge (string or None):    edge for calculation (see Note 2)     [None]
+      cluster_size (float):     size of cluster, in Angstroms         [8.0]
+      absorber_site (int):      index of site for absorber (see Note 3) [1]
+      site_index (int or None): index of site for absorber (see Note 4) [None]
+      extra_titles (list of str or None): extra title lines to include [None]
+      with_h (bool):            whether to include H atoms [False]
+      version8 (bool):          whether to write Feff8l input (see Note 5)[True]
+      fmt (string):             format of structure file (cif, poscar, etc) [cif]
+    Returns
+    -------
+      text of Feff input file
+
+    Notes
+    -----
+      1. absorber is the atomic symbol or number of the absorbing element, and
+         must be an element in the CIF structure.
+      2. If edge is a string, it must be one of 'K', 'L', 'M', or 'N' edges (note
+         Feff6 supports only 'K', 'L3', 'L2', and 'L1' edges). If edge is None,
+         it will be assigned to be 'K' for absorbers with Z < 58 (Ce, with an
+         edge energy < 40 keV), and 'L3' for absorbers with Z >= 58.
+      3. for structures with multiple sites for the absorbing atom, the site
+         can be selected by the order in which they are listed in the sites
+         list. This depends on the details of the CIF structure, which can be
+         found with `cif_sites(ciftext)`, starting counting by 1.
+      4. to explicitly state the index of the site in the sites list, use
+         site_index (starting at 1!)
+      5. if version8 is False, outputs will be written for Feff6l
+
+    """
+    try:
+        struct = read_structure(structure_text, fmt=fmt)
+    except ValueError:
+        return '# could not read structure file'
+  
+    is_molecule = False
+  
+    if isinstance(struct, IStructure):
+        sgroup = SpacegroupAnalyzer(struct).get_symmetry_dataset()
+        space_group = sgroup["international"]
+    else:
+        space_group = 'Molecule'
+        is_molecule = True
+        
+
+    if isinstance(absorber, int):
+        absorber   = atomic_symbol(absorber_z)
+    absorber_z = atomic_number(absorber)
+
+    if edge is None:
+        edge = 'K' if absorber_z < 58 else 'L3'
+
+    edge_energy = xray_edge(absorber, edge).energy
+    edge_comment = f'{absorber:s} {edge:s} edge, around {edge_energy:.0f} eV'
+
+    unique_pot_atoms = []
+    for site in struct:
+        for elem in site.species.elements:
+            if elem.symbol not in unique_pot_atoms:
+                unique_pot_atoms.append(elem.symbol)
+
+    atoms_map = {}
+    for i, atom in enumerate(unique_pot_atoms):
+        atoms_map[atom] = i + 1
+
+    if absorber not in atoms_map:
+        atlist = ', '.join(atoms_map.keys())
+        raise ValueError(f'atomic symbol {absorber:s} not listed in structure data: ({atlist})')
+
+
+    site_atoms = {}  # map xtal site with list of atoms occupying that site
+    site_tags = {}
+    absorber_count = 0
+    for sindex, site in enumerate(struct.sites):
+        site_species = [e.symbol for e in site.species]
+        if len(site_species) > 1:
+            s_els = [s.symbol for s in site.species.keys()]
+            s_wts = [s for s in site.species.values()]
+            site_atoms[sindex] = random.choices(s_els, weights=s_wts, k=1000)
+            site_tags[sindex] = f'({site.species_string:s})_{1+sindex:d}'
+        else:
+            site_atoms[sindex] = [site_species[0]] * 1000
+            site_tags[sindex] = f'{site.species_string:s}_{1+sindex:d}'
+        if absorber in site_species:
+            absorber_count += 1
+            if absorber_count == absorber_site:
+                absorber_index = sindex
+
+    if site_index is not None:
+        absorber_index = site_index - 1
+
+    # print("Got sites ", len(cstruct.sites), len(site_atoms), len(site_tags))
+
+    center = struct[absorber_index].coords
+    sphere = struct.get_neighbors(struct[absorber_index], cluster_size)
+    symbols = [absorber]
+    coords = [[0, 0, 0]]
+    tags = [f'{absorber:s}_{1+absorber_index:d}']
+
+    for i, site_dist in enumerate(sphere):
+        s_index = site_dist[0].index
+
+        site_symbol = site_atoms[s_index].pop()
+        tags.append(site_tags[s_index])
+        symbols.append(site_symbol)
+        coords.append(site_dist[0].coords - center)
+    cluster = Molecule(symbols, coords)
+
+    out_text = ['*** feff input generated by xraylarch cif2feff using pymatgen ***']
+
+    if extra_titles is not None:
+        for etitle in extra_titles[:]:
+            if not etitle.startswith('TITLE '):
+                etitle = 'TITLE ' + etitle
+            out_text.append(etitle)
+
+    out_text.append(f'TITLE Formula:    {struct.composition.reduced_formula:s}')
+    out_text.append(f'TITLE SpaceGroup: {space_group:s}')
+    out_text.append(f'TITLE # sites:    {struct.num_sites}')
+
+    out_text.append('* crystallographics sites: note that these sites may not be unique!')
+    out_text.append(f'*     using absorber at site {1+absorber_index:d} in the list below')
+    out_text.append(f'*     selected as absorber="{absorber:s}", absorber_site={absorber_site:d}')
+    out_text.append('* index   X        Y        Z      species')
+    
+    for i, site in enumerate(struct):
+        # The method of obtaining the cooridanates depends on whether the structure is a molecule or not
+        if is_molecule:
+            fc = site.coords
+        else:
+            fc = site.frac_coords
+        species_string = fix_varname(site.species_string.strip())
+        marker = '  <- absorber' if  (i == absorber_index) else ''
+        out_text.append(f'* {i+1:3d}   {fc[0]:.6f} {fc[1]:.6f} {fc[2]:.6f}  {species_string:s} {marker:s}')
+
+    out_text.extend(['* ', '', ''])
+
+    if version8:
+        out_text.append(f'EDGE    {edge:s}')
+        out_text.append('S02     1.0')
+        out_text.append('CONTROL 1 1 1 1 1 1')
+        out_text.append('PRINT   1 0 0 0 0 3')
+        out_text.append('EXAFS   20.0')
+        out_text.append('NLEG     6')
+        out_text.append(f'RPATH   {cluster_size:.2f}')
+        out_text.append('*SCF    5.0')
+
+    else:
+        edge_index = {'K': 1, 'L1': 2, 'L2': 3, 'L3': 4}[edge]
+        out_text.append(f'HOLE    {edge_index:d}  1.0  * {edge_comment:s} (2nd number is S02)')
+        out_text.append('CONTROL 1 1 1 0 * phase, paths, feff, chi')
+        out_text.append('PRINT   1 0 0 0')
+        out_text.append(f'RMAX    {cluster_size:.2f}')
+
+    out_text.extend(['', 'EXCHANGE 0', '',
+                     '*  POLARIZATION  0 0 0', '',
+                     'POTENTIALS',  '*    IPOT  Z   Tag'])
+
+    # loop to find atoms actually in cluster, in case some atom
+    # (maybe fractional occupation) is not included
+
+    at_lines = [(0, cluster[0].x, cluster[0].y, cluster[0].z, 0, absorber, tags[0])]
+    ipot_map = {}
+    next_ipot = 0
+    for i, site in enumerate(cluster[1:]):
+        sym = site.species_string
+        if sym == 'H' and not with_h:
+            continue
+        if sym in ipot_map:
+            ipot = ipot_map[sym]
+        else:
+            next_ipot += 1
+            ipot_map[sym] = ipot = next_ipot
+
+        dist = cluster.get_distance(0, i+1)
+        at_lines.append((dist, site.x, site.y, site.z, ipot, sym, tags[i+1]))
+
+
+    ipot, z = 0, absorber_z
+    out_text.append(f'   {ipot:4d}  {z:4d}   {absorber:s}')
+    for sym, ipot in ipot_map.items():
+        z = atomic_number(sym)
+        out_text.append(f'   {ipot:4d}  {z:4d}   {sym:s}')
+
+    out_text.append('')
+    out_text.append('ATOMS')
+    out_text.append(f'*    x         y         z       ipot  tag   distance  site_info')
+
+    acount = 0
+    for dist, x, y, z, ipot, sym, tag in sorted(at_lines, key=lambda x: x[0]):
+        acount += 1
+        if acount > 500:
+            break
+        sym = (sym + ' ')[:2]
+        out_text.append(f'   {x: .5f}  {y: .5f}  {z: .5f} {ipot:4d}   {sym:s}    {dist:.5f}  * {tag:s}')
+
+    out_text.append('')
+    out_text.append('* END')
+    out_text.append('')
+    return strict_ascii('\n'.join(out_text))


### PR DESCRIPTION
## Summary

- This PR adds a feature to generate FEFF input files from general structures supported by Pymatgen.
- Main changes are the following. "structure2feff_browser.py" and "larch/xrd/structure2feff.py" were created to be consistent with "cif_browser.py" and "cif2feff.py" as much as possible.
  1. Added a new menu item in the "Feff" menu bar that opens a FEFF input generator.
  2. Added "[structure2feff_browser.py](https://github.com/Ameyanagi/xraylarch/compare/master...Ameyanagi:xraylarch:general-feff-input-generator?expand=1#diff-dfc3a80d03e047864ffbd1978d561c81946385884f1d3ac372a87cb9c8f58cbd)" that handles the GUI of the FEFF input generator.
  3. Added "[larch/xrd/structure2feff.py](https://github.com/Ameyanagi/xraylarch/compare/master...Ameyanagi:xraylarch:general-feff-input-generator?expand=1#diff-9e75acc47d47adf2a7f590906da47eef9f7ea05db62da0699b84329bfc22af5d)" that converts general structures to FEFF input files.
- For example, POSCAR from VASP, XYZ files, GJF files from Gaussian can be read by default functions of Pymatgen. Other formats, such as MOL2 files, supported by OpenBabel can also be read if OpenBabel is installed.

## Other Comments

- Tests have not been written, as I could not find tests for GUI.
- I created new functions as the current cif_browser.py highly depends on the CIF database that is implemented and is focused on parsing CIF files.

